### PR TITLE
Fix some incorrect SGR codes

### DIFF
--- a/PowerShell/Attributes.ps1
+++ b/PowerShell/Attributes.ps1
@@ -103,8 +103,8 @@ function Do-It {
 
     CUP 10 0 ; [console]::Write("Standard attributes:") 
         CUP 11 4 ; SGR  4 ; [console]::Write("Underline") ; SGR 24 ; [console]::Write(" - no underline") ; SGR 0
-        CUP 12 4 ; SGR  5 ; [console]::Write("Slow blink") ; SGR 25 ; [console]::Write(" - no slow blink") ; SGR 0
-        CUP 13 4 ; SGR  6 ; [console]::Write("Rapid blink") ; SGR 26 ; [console]::Write(" - no rapid blink") ; SGR 0
+        CUP 12 4 ; SGR  5 ; [console]::Write("Slow blink") ; SGR 25 ; [console]::Write(" - no blink") ; SGR 0
+        CUP 13 4 ; SGR  6 ; [console]::Write("Rapid blink") ; SGR 25 ; [console]::Write(" - no blink") ; SGR 0
         CUP 14 4 ; SGR  7 ; [console]::Write("Inverse") ; SGR 27 ; [console]::Write(" - no inverse") ; SGR 0
         CUP 15 4 ; SGR  8 ; [console]::Write("Invisible") ; SGR 28 ; [console]::Write(" - no invisible") ; SGR 0
         CUP 16 4 ; SGR  9 ; [console]::Write("Strikethrough") ; SGR 29 ; [console]::Write(" - no strikethrough") ; SGR 0

--- a/PowerShell/ColourMatrix.ps1
+++ b/PowerShell/ColourMatrix.ps1
@@ -60,8 +60,8 @@ function Set-16Colour {
             }
             "V" {
                 $sgr = if ($isbg) {48} else {38}
-                $pn = if ($script:conformant) { ECMA48SubParams $sgr, 5, $index } else { ECMA48Params $sgr, 5, $index }
-                [console]::Write([string]::format("{0}{1}m", $CSI, $pn))
+                $param = if ($script:conformant) { $(ECMA48SubParams 5, $index) } else { $(ECMA48Params 5, $index) }
+                [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $sgr, $param)))
             }
             "T" {
                 $sgr = if ($isbg) {48} else {38}
@@ -75,8 +75,8 @@ function Set-16Colour {
                     $g = (($index -band 2) / 2) * $v
                     $b = (($index -band 4) / 4) * $v
                 }
-                $pn = if ($script:conformant) { ECMA48SubParams $sgr, 2, $null, $r, $g, $b } else { ECMA48Params $sgr, 2, $r, $g, $b }
-                [console]::Write([string]::format("{0}{1}m", $CSI, $pn))
+                $param = if ($script:conformant) { ECMA48SubParams 2, $null, $r, $g, $b } else { ECMA48Params 2, $r, $g, $b }
+                [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $sgr, $param)))
             }
         }
     } else {
@@ -105,14 +105,14 @@ function Set-Greyscale {
             }
             "V" {
                 $sgr = if ($isbg) {48} else {38}
-                $pn = if ($script:conformant) { ECMA48SubParams $sgr, 5, $($index + 232) } else { ECMA48Params $sgr, 5, $($index + 232) }
-                [console]::Write([string]::format("{0}{1}m", $CSI, $pn))
+                $param = if ($script:conformant) { ECMA48SubParams 5, $($index + 232) } else { ECMA48Params 5, $($index + 232) }
+                [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $sgr, $param)))
             }
             "T" {
                 $index = 8 + $index * 10
                 $sgr = if ($isbg) {48} else {38}
-                $pn = if ($script:conformant) { ECMA48SubParams $sgr, 2, $null, $index, $index, $index } else { ECMA48Params $sgr, 2, $index, $index, $index }
-                [console]::Write([string]::format("{0}{1}m", $CSI, $pn))
+                $param = if ($script:conformant) { ECMA48SubParams 2, $null, $index, $index, $index } else { ECMA48Params 2, $index, $index, $index }
+                [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $sgr, $param)))
             }
         }
     } else {


### PR DESCRIPTION
I came across this as a suggested test suite for Windows Terminal, and while trying it out, I hit a few issues:
* The 'Rapid blink' line continued blinking in the no-blink section
* The SGR 38 and 48 colour parameters incorrectly implemented the ITU T.416-conformant layout.

Windows Terminal doesn't currently _implement_ the latter, but there was a fair bit of research done on https://github.com/microsoft/terminal/issues/4321 as preparation work. Per https://gist.github.com/XVilka/8346728#gistcomment-2774523 there is some ambiguity in the specification, so for the purposes of this repo, it might make sense to make that change toggleable as well?