### PR TITLE
Add colours to Attributes.ps1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"cSpell.language": "en-gb"
+}

--- a/PowerShell/Attributes.ps1
+++ b/PowerShell/Attributes.ps1
@@ -2,7 +2,7 @@
 ## For copyright and licensing terms, see the file named LICENSE.
 ## **************************************************************************
 
-## A test of SGR character attributes
+## A test of SGR character attributes and ISO colours
 ## This includes the KiTTY extensions to SGR 4.
 
 if ($host.PrivateData -and $host.PrivateData.GetType().Name -eq "ISEOptions") {
@@ -60,10 +60,19 @@ function DECSCNM {
     DECPrivateMode 5 $v
 }
 
+function pseudoSGR0 {
+    SGR 0
+    if($script:colour_all) {
+        SGR $script:fg_colour $script:bg_colour
+    }
+}
+
 function Do-It {
     CUP
     SGR
 	DECSCNM $($script:scnm -gt 0)
+
+    pseudoSGR0
     ED 2
 
     CUP  1 0 ; [console]::Write("Font weights and slants:")
@@ -71,66 +80,76 @@ function Do-It {
             SGR  1 ; [console]::Write("Upright boldface") ;
             SGR  2 ; [console]::Write(" - demibold (faint boldface)") ;
             SGR 22 ; [console]::Write(" - not boldface nor demibold") ;
-            SGR 0
+            pseudoSGR0
         CUP  3 4 ;
-            SGR  0 ; [console]::Write("Upright medium (normal)")
+            SGR  0 ; pseudoSGR0 ; [console]::Write("Upright medium (normal)")
             SGR  2 ; [console]::Write(" - light (faint normal)") ;
             SGR 22 ; [console]::Write(" - not light") ;
-            SGR 0
+            pseudoSGR0
         CUP  4 4 ;
             SGR  1 3 ; [console]::Write("Italic boldface") ;
             SGR  2 ; [console]::Write(" - demibold (faint boldface)") ;
             SGR 22 ; [console]::Write(" - not boldface nor demibold") ;
-            SGR 0
+            pseudoSGR0
         CUP  5 4 ;
             SGR  3 ; [console]::Write("Italic medium (normal)")
             SGR  2 ; [console]::Write(" - light (faint normal)") ;
             SGR 22 ; [console]::Write(" - not light") ;
-            SGR 0
-        CUP  7 4 ; SGR  3 ; [console]::Write("Italic") ; SGR 23 ; [console]::Write(" - no italic") ; SGR 0
+            pseudoSGR0
+        CUP  7 4 ; SGR  3 ; [console]::Write("Italic") ; SGR 23 ; [console]::Write(" - no italic") ; pseudoSGR0
         CUP  8 4 ;
-            SGR 10 ; [console]::Write("SGR 10") ; SGR 0 ; [console]::Write(" - ")
-            SGR 11 ; [console]::Write("SGR 11") ; SGR 0 ; [console]::Write(" - ")
-            SGR 12 ; [console]::Write("SGR 12") ; SGR 0 ; [console]::Write(" - ")
-            SGR 13 ; [console]::Write("SGR 13") ; SGR 0 ; [console]::Write(" - ")
-            SGR 14 ; [console]::Write("SGR 14") ; SGR 0 ; [console]::Write(" - ")
-            SGR 15 ; [console]::Write("SGR 15") ; SGR 0 ; [console]::Write(" - ")
-            SGR 16 ; [console]::Write("SGR 16") ; SGR 0 ; [console]::Write(" - ")
-            SGR 17 ; [console]::Write("SGR 17") ; SGR 0 ; [console]::Write(" - ")
-            SGR 18 ; [console]::Write("SGR 18") ; SGR 0 ; [console]::Write(" - ")
-            SGR 19 ; [console]::Write("SGR 19") ; SGR 0 ; #[console]::Write(" - ")
+            SGR 10 ; [console]::Write("SGR 10") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 11 ; [console]::Write("SGR 11") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 12 ; [console]::Write("SGR 12") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 13 ; [console]::Write("SGR 13") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 14 ; [console]::Write("SGR 14") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 15 ; [console]::Write("SGR 15") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 16 ; [console]::Write("SGR 16") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 17 ; [console]::Write("SGR 17") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 18 ; [console]::Write("SGR 18") ; pseudoSGR0 ; [console]::Write(" - ")
+            SGR 19 ; [console]::Write("SGR 19") ; pseudoSGR0 ; #[console]::Write(" - ")
 
 
     CUP 10 0 ; [console]::Write("Standard attributes:")
-        CUP 11 4 ; SGR  4 ; [console]::Write("Underline") ; SGR 24 ; [console]::Write(" - no underline") ; SGR 0
-        CUP 12 4 ; SGR  5 ; [console]::Write("Slow blink") ; SGR 25 ; [console]::Write(" - no slow blink") ; SGR 0
-        CUP 13 4 ; SGR  6 ; [console]::Write("Rapid blink") ; SGR 26 ; [console]::Write(" - no rapid blink") ; SGR 0
-        CUP 14 4 ; SGR  7 ; [console]::Write("Inverse") ; SGR 27 ; [console]::Write(" - no inverse") ; SGR 0
-        CUP 15 4 ; SGR  8 ; [console]::Write("Invisible") ; SGR 28 ; [console]::Write(" - no invisible") ; SGR 0
-        CUP 16 4 ; SGR  9 ; [console]::Write("Strikethrough") ; SGR 29 ; [console]::Write(" - no strikethrough") ; SGR 0
-        CUP 17 4 ; SGR 53 ; [console]::Write("Overline") ; SGR 55 ; [console]::Write(" - no overline") ; SGR 0
-        CUP 18 4 ; SGR 51 ; [console]::Write("Framed") ; SGR 54 ; [console]::Write(" - not framed") ; SGR 0
-        CUP 19 4 ; SGR 52 ; [console]::Write("Encircled") ; SGR 54 ; [console]::Write(" - not encircled") ; SGR 0
+        CUP 11 4 ; SGR  4 ; [console]::Write("Underline") ; SGR 24 ; [console]::Write(" - no underline") ; pseudoSGR0
+        CUP 12 4 ; SGR  5 ; [console]::Write("Slow blink") ; SGR 25 ; [console]::Write(" - no slow blink") ; pseudoSGR0
+        CUP 13 4 ; SGR  6 ; [console]::Write("Rapid blink") ; SGR 26 ; [console]::Write(" - no rapid blink") ; pseudoSGR0
+        CUP 14 4 ; SGR  7 ; [console]::Write("Inverse") ; SGR 27 ; [console]::Write(" - no inverse") ; pseudoSGR0
+        CUP 15 4 ; SGR  8 ; [console]::Write("Invisible") ; SGR 28 ; [console]::Write(" - no invisible") ; pseudoSGR0
+        CUP 16 4 ; SGR  9 ; [console]::Write("Strikethrough") ; SGR 29 ; [console]::Write(" - no strikethrough") ; pseudoSGR0
+        CUP 17 4 ; SGR 53 ; [console]::Write("Overline") ; SGR 55 ; [console]::Write(" - no overline") ; pseudoSGR0
+        CUP 18 4 ; SGR 51 ; [console]::Write("Framed") ; SGR 54 ; [console]::Write(" - not framed") ; pseudoSGR0
+        CUP 19 4 ; SGR 52 ; [console]::Write("Encircled") ; SGR 54 ; [console]::Write(" - not encircled") ; pseudoSGR0
 
+    $fgName = $script:foreground_colour_combobox.Text
+    $bgName = $script:background_colour_combobox.Text
+    CUP 21 0
+        pseudoSGR0 ; [console]::Write("ISO colours: ") ; pseudoSGR0
+        CUP 21 13 ; SGR $script:fg_colour ; [console]::Write("##") ; pseudoSGR0 ; [console]::Write(" $fgName ($script:fg_colour)")
+        CUP 21 28 ;[console]::Write(" on ")
+        SGR $script:bg_colour ; [console]::Write("  ") ; pseudoSGR0 ; [console]::Write(" $bgName ($script:bg_colour)")
+        CUP 21 47 ; [console]::Write(" gives ")
+        SGR $script:fg_colour $script:bg_colour ; [console]::Write("this") ; pseudoSGR0
+        pseudoSGR0
 
 # See https://github.com/kovidgoyal/kitty/issues/226
-    CUP 21 0 ; [console]::Write("SGR 4 extensions to provide underline variants: ") ;
-    CUP 22 4
-        SGR $(ECMA48SubParams 4 $null) ; [console]::Write("empty-default ") ; SGR 24
-        SGR $(ECMA48SubParams 4 0) ; [console]::Write("zero-default ") ; SGR 24
-        SGR $(ECMA48SubParams 4 1) ; [console]::Write("single ") ; SGR 24
-        SGR $(ECMA48SubParams 4 2) ; [console]::Write("double ") ; SGR 24
-        SGR $(ECMA48SubParams 4 3) ; [console]::Write("scurly ") ; SGR 24
-        SGR $(ECMA48SubParams 4 4) ; [console]::Write("dotted ") ; SGR 24
-        SGR $(ECMA48SubParams 4 5) ; [console]::Write("dashed ") ; SGR 24
-        SGR $(ECMA48SubParams 4 6) ; [console]::Write("ldashed ") ; SGR 24
-        SGR $(ECMA48SubParams 4 7) ; [console]::Write("lldashed ") ; SGR 24
-        SGR $(ECMA48SubParams 4 8) ; [console]::Write("ldotted ") ; SGR 24
-        SGR $(ECMA48SubParams 4 9) ; [console]::Write("lcurly ") ; SGR 24
-        SGR 0
+    CUP 23 0 ; [console]::Write("SGR 4 extensions to provide underline variants: ") ;
+    CUP 24 4
+        SGR $(ECMA48SubParams 4 $null) ; [console]::Write("empty-default ") ; SGR 26
+        SGR $(ECMA48SubParams 4 0) ; [console]::Write("zero-default ") ; SGR 26
+        SGR $(ECMA48SubParams 4 1) ; [console]::Write("single ") ; SGR 26
+        SGR $(ECMA48SubParams 4 2) ; [console]::Write("double ") ; SGR 26
+        SGR $(ECMA48SubParams 4 3) ; [console]::Write("scurly ") ; SGR 26
+        SGR $(ECMA48SubParams 4 4) ; [console]::Write("dotted ") ; SGR 26
+        SGR $(ECMA48SubParams 4 5) ; [console]::Write("dashed ") ; SGR 26
+        SGR $(ECMA48SubParams 4 6) ; [console]::Write("ldashed ") ; SGR 26
+        SGR $(ECMA48SubParams 4 7) ; [console]::Write("lldashed ") ; SGR 26
+        SGR $(ECMA48SubParams 4 8) ; [console]::Write("ldotted ") ; SGR 26
+        SGR $(ECMA48SubParams 4 9) ; [console]::Write("lcurly ") ; SGR 26
+        pseudoSGR0
 
     SGR
-    CUP 23 0
+    CUP 25 0
 }
 
 Add-Type -AssemblyName System.Windows.Forms
@@ -178,12 +197,54 @@ $background_checkbox.AutoSize = $true
 $background_checkbox.Top = $csi_label.Top + $vertical_grid + 10
 $background_checkbox.Left = $csi_label.Left
 
+# colour selectors
+$colours = @('Black', 'Red', 'Green', 'Yellow', 'Blue', 'Magenta', 'Cyan', 'White', 'Default')
+function indexToColour($index, $fg){
+    if($index -ge 8 -or $index -lt 0) {
+        $index = 9; # clamp to "default"
+    }
+    $index + ($fg ? 30 : 40)
+}
+function makeColourCB($fg){
+    $cb = New-Object System.Windows.Forms.ComboBox
+    $cb.AutoSize = $true
+    foreach($colour in $script:colours){
+        $cb.Items.Add($colour) | Out-Null
+    }
+    $cb.SelectedIndex = 8;
+    $cb.add_SelectedIndexChanged($fg ? {
+        $script:fg_colour = ($script:foreground_colour_combobox.SelectedIndex + 0) + 30;
+        Click
+    } : {
+        $script:bg_colour = ($script:background_colour_combobox.SelectedIndex + 0) + 40;
+        Click
+    })
+    return $cb
+}
+
+$foreground_colour_combobox = makeColourCB($true)
+$foreground_colour_combobox.Top = $background_checkbox.Top + $vertical_grid + 10
+$foreground_colour_combobox.Left = $background_checkbox.Left
+
+$background_colour_combobox = makeColourCB($false)
+$background_colour_combobox.Top = $foreground_colour_combobox.Top + $vertical_grid + 10
+$background_colour_combobox.Left = $foreground_colour_combobox.Left
+
+$colour_all_checkbox = New-Object System.Windows.Forms.CheckBox
+$colour_all_checkbox.Text = "Colour all text"
+$colour_all_checkbox.AutoSize = $true
+$colour_all_checkbox.Top = $background_colour_combobox.Top + $vertical_grid + 10
+$colour_all_checkbox.Left = $background_colour_combobox.Left
+
 # main form
 
 $form = New-Object System.Windows.Forms.Form
 $form.Controls.Add($csi_label)
 $form.Controls.Add($csi_groupbox)
 $form.Controls.Add($background_checkbox)
+$form.Controls.Add($foreground_colour_combobox)
+$form.Controls.Add($background_colour_combobox)
+$form.Controls.Add($colour_all_checkbox)
 $form.Text = "SGR attributes test"
 $form.AutoSize = $true
 $form.Opacity = 0.9
@@ -193,6 +254,7 @@ $form.Opacity = 0.9
 function Click {
     C1
     $script:scnm = $script:background_checkbox.Checked
+    $script:colour_all = $script:colour_all_checkbox.Checked
     Do-It
 }
 
@@ -203,11 +265,15 @@ if ([Console]::OutputEncoding.IsSingleByte) {
 }
 $scnm = $false
 $background_checkbox.Checked = $true
+$colour_all = $false
+$fg_colour = 39
+$bg_colour = 49
 
 $csi7_radiobutton.add_Click({Click})
 $csi8_radiobutton.add_Click({Click})
 $csiu_radiobutton.add_Click({Click})
 $background_checkbox.add_Click({Click})
+$colour_all_checkbox.add_Click({Click})
 
 Click
 

--- a/PowerShell/Attributes.ps1
+++ b/PowerShell/Attributes.ps1
@@ -14,7 +14,7 @@ function C1 {
     if ($script:csi7_radiobutton.Checked) {
         $script:CSI = [char]27 + [char]0x5B
         [Console]::OutputEncoding = [System.Text.Encoding]::ASCII
-    } else { 
+    } else {
         $script:CSI = [char]0x9B
         if ($script:csi8_radiobutton.Checked) {
             [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -36,27 +36,27 @@ function ECMA48SubParams {
     [String]::Join(":",$a)
 }
 
-function CUP { 
-    [console]::Write([string]::format("{0}{1}H", $CSI, $(ECMA48Params $args))) 
+function CUP {
+    [console]::Write([string]::format("{0}{1}H", $CSI, $(ECMA48Params $args)))
 }
 
 function ED {
-    param ($p = 2) 
-    [console]::Write([string]::format("{0}{1:D}J", $CSI, $p)) 
+    param ($p = 2)
+    [console]::Write([string]::format("{0}{1:D}J", $CSI, $p))
 }
 
-function SGR { 
-    [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $args))) 
+function SGR {
+    [console]::Write([string]::format("{0}{1}m", $CSI, $(ECMA48Params $args)))
 }
 
 function DECPrivateMode {
-    param ($m = 1, $v = $true) 
+    param ($m = 1, $v = $true)
     $v = if ($v) {"h"} else {"l"}
-    [console]::Write([string]::format("{0}?{1:D}{2}", $CSI, $m, $v)) 
+    [console]::Write([string]::format("{0}?{1:D}{2}", $CSI, $m, $v))
 }
 
 function DECSCNM {
-    param ($v = $true) 
+    param ($v = $true)
     DECPrivateMode 5 $v
 }
 
@@ -66,29 +66,29 @@ function Do-It {
 	DECSCNM $($script:scnm -gt 0)
     ED 2
 
-    CUP  1 0 ; [console]::Write("Font weights and slants:") 
-        CUP  2 4 ; 
-            SGR  1 ; [console]::Write("Upright boldface") ; 
-            SGR  2 ; [console]::Write(" - demibold (faint boldface)") ; 
-            SGR 22 ; [console]::Write(" - not boldface nor demibold") ; 
+    CUP  1 0 ; [console]::Write("Font weights and slants:")
+        CUP  2 4 ;
+            SGR  1 ; [console]::Write("Upright boldface") ;
+            SGR  2 ; [console]::Write(" - demibold (faint boldface)") ;
+            SGR 22 ; [console]::Write(" - not boldface nor demibold") ;
             SGR 0
-        CUP  3 4 ; 
-            SGR  0 ; [console]::Write("Upright medium (normal)") 
-            SGR  2 ; [console]::Write(" - light (faint normal)") ; 
-            SGR 22 ; [console]::Write(" - not light") ; 
+        CUP  3 4 ;
+            SGR  0 ; [console]::Write("Upright medium (normal)")
+            SGR  2 ; [console]::Write(" - light (faint normal)") ;
+            SGR 22 ; [console]::Write(" - not light") ;
             SGR 0
-        CUP  4 4 ; 
-            SGR  1 3 ; [console]::Write("Italic boldface") ; 
-            SGR  2 ; [console]::Write(" - demibold (faint boldface)") ; 
-            SGR 22 ; [console]::Write(" - not boldface nor demibold") ; 
+        CUP  4 4 ;
+            SGR  1 3 ; [console]::Write("Italic boldface") ;
+            SGR  2 ; [console]::Write(" - demibold (faint boldface)") ;
+            SGR 22 ; [console]::Write(" - not boldface nor demibold") ;
             SGR 0
-        CUP  5 4 ; 
-            SGR  3 ; [console]::Write("Italic medium (normal)") 
-            SGR  2 ; [console]::Write(" - light (faint normal)") ; 
-            SGR 22 ; [console]::Write(" - not light") ; 
+        CUP  5 4 ;
+            SGR  3 ; [console]::Write("Italic medium (normal)")
+            SGR  2 ; [console]::Write(" - light (faint normal)") ;
+            SGR 22 ; [console]::Write(" - not light") ;
             SGR 0
         CUP  7 4 ; SGR  3 ; [console]::Write("Italic") ; SGR 23 ; [console]::Write(" - no italic") ; SGR 0
-        CUP  8 4 ; 
+        CUP  8 4 ;
             SGR 10 ; [console]::Write("SGR 10") ; SGR 0 ; [console]::Write(" - ")
             SGR 11 ; [console]::Write("SGR 11") ; SGR 0 ; [console]::Write(" - ")
             SGR 12 ; [console]::Write("SGR 12") ; SGR 0 ; [console]::Write(" - ")
@@ -99,9 +99,9 @@ function Do-It {
             SGR 17 ; [console]::Write("SGR 17") ; SGR 0 ; [console]::Write(" - ")
             SGR 18 ; [console]::Write("SGR 18") ; SGR 0 ; [console]::Write(" - ")
             SGR 19 ; [console]::Write("SGR 19") ; SGR 0 ; #[console]::Write(" - ")
-        
 
-    CUP 10 0 ; [console]::Write("Standard attributes:") 
+
+    CUP 10 0 ; [console]::Write("Standard attributes:")
         CUP 11 4 ; SGR  4 ; [console]::Write("Underline") ; SGR 24 ; [console]::Write(" - no underline") ; SGR 0
         CUP 12 4 ; SGR  5 ; [console]::Write("Slow blink") ; SGR 25 ; [console]::Write(" - no slow blink") ; SGR 0
         CUP 13 4 ; SGR  6 ; [console]::Write("Rapid blink") ; SGR 26 ; [console]::Write(" - no rapid blink") ; SGR 0
@@ -111,10 +111,10 @@ function Do-It {
         CUP 17 4 ; SGR 53 ; [console]::Write("Overline") ; SGR 55 ; [console]::Write(" - no overline") ; SGR 0
         CUP 18 4 ; SGR 51 ; [console]::Write("Framed") ; SGR 54 ; [console]::Write(" - not framed") ; SGR 0
         CUP 19 4 ; SGR 52 ; [console]::Write("Encircled") ; SGR 54 ; [console]::Write(" - not encircled") ; SGR 0
-        
-    
+
+
 # See https://github.com/kovidgoyal/kitty/issues/226
-    CUP 21 0 ; [console]::Write("SGR 4 extensions to provide underline variants: ") ; 
+    CUP 21 0 ; [console]::Write("SGR 4 extensions to provide underline variants: ") ;
     CUP 22 4
         SGR $(ECMA48SubParams 4 $null) ; [console]::Write("empty-default ") ; SGR 24
         SGR $(ECMA48SubParams 4 0) ; [console]::Write("zero-default ") ; SGR 24
@@ -128,7 +128,7 @@ function Do-It {
         SGR $(ECMA48SubParams 4 8) ; [console]::Write("ldotted ") ; SGR 24
         SGR $(ECMA48SubParams 4 9) ; [console]::Write("lcurly ") ; SGR 24
         SGR 0
-    
+
     SGR
     CUP 23 0
 }


### PR DESCRIPTION
_tl;dr:_ I made a quick test with adding colors to the attributes test, making a pull request in case it is of interest just to share my hacking :)

It's just a quick test (e.g. I didn't bother adding labels to the fore- and background selectors), so it probably would need some adjustments in that regard at least.

Also took the liberty of adding a `settings.json` which sets the spelling language to British English (`en_GB`) on a hunch based on the ".uk" link on your profile (went with the spelling "colour" in the source based on that guess too).

This branch basically adds two combo-boxes for choosing the fore- and background color of the text, and a checkbox whether to combine that with the other attributes or not. The colors are the basic "ISO colors" for the SGR rage 30-37,39 (and 4x ditto).

However I didn't implement [256-color](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#256-colors) or [RGB truecolor](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#rgb-colors) support. (Which ironically what was I was originally fiddling with in combination with the bold attr.)

So, in other words feel free to do as you please with it.